### PR TITLE
Changes to work with M3D Fio

### DIFF
--- a/Controller-NTC/Controller-NTC.ino
+++ b/Controller-NTC/Controller-NTC.ino
@@ -328,12 +328,13 @@ void loop() {
       Serial.print(Command);
       LEDSwitch();
     } else if (TOFlag) {
-      Serial.print(temp);
+      Serial.println(temp);
       if (!TWFlag) {
         TOFlag = false;
       } else {
         tempLast = (tempLast + temp) / 2;
         if (tempLast >= goalTemp) {
+          Serial.println("ok");
           TWFlag = false;
           TOFlag = false;
           TimerUpdate(UpdateTime);


### PR DESCRIPTION
M3D Fio couldn't reliably read the temperature output during the w command without the carriage returns after each of them. And the serial read timeouts weren't happening like I wanted, so adding the confirmation, 'ok', after a w command finished was a good alternative.
